### PR TITLE
Load README via fetch

### DIFF
--- a/components/contact-dialog.php
+++ b/components/contact-dialog.php
@@ -1,5 +1,5 @@
 <?php
-$dialog = $footer->append('dialog', null, ['id' => 'contact-dialog']);
+$dialog = $dom->body->getElementsByTagName('footer')->item(0)->append('dialog', null, ['id' => 'contact-dialog']);
 $dialog->append('button', null, [
 	'type' => 'button',
 	'data-close' => '#contact-dialog'

--- a/components/footer.php
+++ b/components/footer.php
@@ -1,14 +1,26 @@
 <?php
 $footer = $dom->body->append('footer');
-\KVSun\Load('readme');
-$footer->append('button', null, [
+$footer->append('a', null, [
 	'title' => 'View README/documentation',
-	'data-show-modal' => "#{$readme->id}"
+	'href' => './?load=readme',
+	'role' => 'button'
+	// 'data-show-modal' => "#{$readme->id}"
 ])->append('svg', null, [
 	'height' => 50,
 	'width' => 50
 ])->append('use', null, [
 	'xlink:href' => 'images/icons.svg#book'
 ]);
-unset($parsedown, $readme);
-require_once './components/contact-dialog.php';
+$footer->append('button', null, [
+	'title' => 'Contact info',
+	'data-show-modal' => '#contact-dialog'
+])->append('svg', null, [
+	'height' => 50,
+	'width' => 50
+])->append('use', null, [
+	'xlink:href' => 'images/icons.svg#person'
+]);
+
+\KVSun\load('contact-dialog');
+return $footer;
+// require_once './components/contact-dialog.php';

--- a/components/readme.php
+++ b/components/readme.php
@@ -1,19 +1,9 @@
 <?php
 $parsedown = new \Parsedown\Parsedown();
-$footer = $dom->body->getElementsByTagName('footer')->item(0);
-$readme = $footer->append('dialog', null, ['id' => 'README-dialog']);
+$readme = $dom->body->append('dialog', null, ['id' => 'README-dialog']);
 $readme->append('button', null, [
 	'type' => 'button',
 	'data-close' => "#{$readme->id}"
 ]);
 $readme->append('br');
 $readme->importHTML($parsedown->text(file_get_contents('README.md')));
-$footer->append('button', null, [
-	'title' => 'Contact info',
-	'data-show-modal' => '#contact-dialog'
-])->append('svg', null, [
-	'height' => 50,
-	'width' => 50
-])->append('use', null, [
-	'xlink:href' => 'images/icons.svg#person'
-]);

--- a/index.php
+++ b/index.php
@@ -8,7 +8,27 @@ if (in_array('text/html', explode(',', $headers->accept))) {
 	\KVSun\load('head', 'header', 'main', 'forms/ad-insertion', 'footer');
 	exit($dom);
 } elseif ($headers->accept === 'application/json' and !empty($_REQUEST)) {
+	$resp = \shgysk8zer0\Core\JSON_Response::load();
+	if (array_key_exists('load', $_REQUEST)) {
+		switch($_REQUEST['load']) {
+			case 'readme':
+				$parsedown = new \Parsedown\Parsedown();
 
-	$headers->content_type = 'application/json';
-	exit(json_encode(['post' => $_POST, 'file' => $_FILES]));
+				$dom = \shgysk8zer0\DOM\HTML::getInstance();
+				$readme = $dom->body->append('dialog', null, ['id' => 'README-dialog']);
+				$readme->append('button', null, [
+					'type' => 'button',
+					'data-delete' => "#{$readme->id}"
+				]);
+				$readme->append('br');
+				$readme->importHTML($parsedown->text(file_get_contents('README.md')));
+				$resp->append('body', $readme);
+				$resp->showModal("#{$readme->id}");
+				break;
+		}
+	}
+	$resp->send();
+	exit();
+} else {
+	http_response_code(404);
 }

--- a/stylesheets/styles/icons.css
+++ b/stylesheets/styles/icons.css
@@ -2,5 +2,6 @@ svg > use {
 	fill: currentColor;
 }
 button, [role="button"] {
+	display: inline-block;
 	color: var(--alt-color);
 }


### PR DESCRIPTION
- Creates a sloppy handler for request in `index.php`, which should
  later be moved to separate script.
- Remove any other loading of README
- Set `[role="button"]` styles to `display: inline-block` (needs to be
  ran through Myth)
