### PR TITLE
Add placeholders to inputs. Fixes #70

### DIFF
--- a/components/forms/ad-insertion.php
+++ b/components/forms/ad-insertion.php
@@ -19,6 +19,7 @@ $section->append('input', null, [
 	'name' => 'ad-insertion[by]',
 	'id' => 'ad-insertion[by]',
 	'pattern' => '[A-z ]+',
+	'placeholder' => 'Your name',
 	'required' => true
 ]);
 $section->append('br');
@@ -51,6 +52,7 @@ $section->append('input', null, [
 	'type' => 'text',
 	'name' => 'ad-insertion[classification]',
 	'id' => 'ad-insertion[classification]',
+	'placeholder' => '???',
 	'required' => true
 ]);
 $section->append('label', null, [
@@ -59,6 +61,7 @@ $section->append('label', null, [
 $section->append('input', null, [
 	'type' => 'text',
 	'name' => 'ad-insertion[special-edition]',
+	'placeholder' => '???',
 	'id' => 'ad-insertion[special-edition]'
 ]);
 unset($section);
@@ -71,6 +74,7 @@ $contact->append('input', null, [
 	'name' => 'ad-insertion[acct-name]',
 	'id' => 'ad-insertion[acct-name]',
 	'pattern' => '[\w ]+',
+	'placeholder' => 'Business name',
 	'required' => ''
 ]);
 $contact->append('br');
@@ -79,7 +83,7 @@ $contact->append('input', null, [
 	'type' => 'text',
 	'name' => 'ad-insertion[contact]',
 	'id' => 'ad-insertion[contact]',
-	// 'placeholder' => 'First Last',
+	'placeholder' => 'First Last',
 	'pattern' => '[A-z \.]+',
 	'required' => ''
 ]);
@@ -88,6 +92,7 @@ $contact->append('input', null, [
 	'type' => 'tel',
 	'name' => 'ad-insertion[phone]',
 	'id' => 'ad-insertion[phone]',
+	'placeholder' => '123456789',
 	'required' => ''
 ]);
 $contact->append('br');
@@ -97,6 +102,7 @@ $contact->append('input', null, [
 	'name' => 'ad-insertion[address]',
 	'id' => 'ad-insertion[address]',
 	'pattern' => '[\w \.]+',
+	'placeholder' => '123 Easy St.',
 	'required' => ''
 ]);
 unset($contact);
@@ -111,6 +117,7 @@ $charges->append('input', null, [
 	'min' => '0',
 	'step' => 0.01,
 	'value' => '0',
+	'placeholder' => '50.00',
 	'required' => ''
 ]);
 $charges->append('label', 'Color Rate: ',['for' => 'ad-insertion[color-rate]']);
@@ -121,6 +128,7 @@ $charges->append('input', null, [
 	'min' => '0',
 	'step' => 0.01,
 	'value' => '0',
+	'placeholder' => 5.25,
 	'required' => ''
 ]);
 $charges->append('label', 'Full ', ['for' => 'ad-insertion[q][full]']);
@@ -128,7 +136,8 @@ $charges->append('input', null, [
 	'type' => 'radio',
 	'name' => 'ad-insertion[q]',
 	'id' => 'ad-insertion[q][full]',
-	'value' => 'full'
+	'value' => 'full',
+	'placeholder' => '???'
 ]);
 $charges->append('label', '1 ', ['for' => 'ad-insertion[q][1]']);
 $charges->append('input', null, [
@@ -155,6 +164,7 @@ $charges->append('input', null, [
 	'min' => '1',
 	'max' => '6',
 	'step' => '1',
+	'placeholder' => 3,
 	'required' => ''
 ]);
 $charges->append('label', 'Height: ', ['for' => 'ad-insertion[size][height]']);
@@ -165,6 +175,7 @@ $charges->append('input', null, [
 	'min' => '1',
 	'max' => '21',
 	'step' => '0.5',
+	'placeholder' => 5,
 	'required' => ''
 ]);
 $charges->append('h2', 'Run Dates');
@@ -193,14 +204,16 @@ $charges->append('label', null, [
 $charges->append('input', null, [
 	'type' => 'text',
 	'name' => 'ad-insertion[sheets]',
-	'id' => 'ad-insertion[sheets]'
+	'id' => 'ad-insertion[sheets]',
+	'placeholder' => '???'
 ]);
 $charges->append('br');
 $charges->append('label', null, ['for' => 'ad-insertion[pu]'])->append('abbr', 'P/U', ['title' => 'Pick-Up']);
 $charges->append('input', null, [
 	'type' => 'text',
 	'name' => 'ad-insertion[pu]',
-	'id' => 'ad-insertion[pu]'
+	'id' => 'ad-insertion[pu]',
+	'placeholder' => '???'
 ]);
 unset($charges);
 
@@ -210,6 +223,7 @@ $info->append('br');
 $info->append('textarea', null, [
 	'name' => 'ad-insertion[info]',
 	'id' => 'ad-insertion[info]',
+	'placeholder' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur. Donec ut libero sed arcu vehicula ultricies a non tortor.',
 	'required' => ''
 ]);
 $info->append('br');


### PR DESCRIPTION
## Add `placeholder`s to inputs in `ad-insertion`

![screenshot](https://i.imgur.com/1hq5LJO.png)

Some might not be very helpful, but that's because I don't know what the
inputs are for.

@KVSun/developers
