### PR TITLE
Update README close button to delete

### DIFF
--- a/components/readme.php
+++ b/components/readme.php
@@ -4,7 +4,7 @@ $readme = \shgysk8zer0\DOM\HTML::getInstance()->createElement('dialog');
 $readme->id = 'README-dailog';
 $readme->append('button', null, [
 	'type' => 'button',
-	'data-close' => "#{$readme->id}"
+	'data-delete' => "#{$readme->id}"
 ]);
 $readme->append('br');
 $readme->importHTML($parsedown->text(file_get_contents('README.md')));


### PR DESCRIPTION
## Fix deleting of README `<dialog>`. Fixes #79
### List of significant changes made
-  Change button's `data-close` to `data-delete`

@KVSun/developers

Change `data-close` to `data-delete`.

Seems to correct event handlers as well.
