### PR TITLE
List unloaded PHP extensions

### DIFF
--- a/components/main.php
+++ b/components/main.php
@@ -1,2 +1,69 @@
 <?php
-return \shgysk8zer0\DOM\HTML::getInstance()->createElement('main');
+namespace KVSUN\Components\Main
+{
+	/**
+	 * Returns a link for a PHP search for an extension
+	 *
+	 * @param  string $extension The module name
+	 * @return string            URL for search on PHP.net
+	 */
+	function getPHPLink($extension)
+	{
+		$params = new \shgysk8zer0\Core\URLSearchParams();
+		$params->pattern = $extension;
+		return "https://php.net/search.php?$params";
+	}
+
+	/**
+	 * Create a <ul> of missing extensions with links to PHP.net
+	 *
+	 * @param  Array      $extensions Array of mising extensions
+	 * @param  DOMElement $parent     Parent element to append list to
+	 * @return DOMElement             The <ul>
+	 */
+	function listExtenions(Array $extensions, \DOMElement $parent)
+	{
+		if (! empty($extensions)) {
+			return array_reduce($extensions, function(\DOMElement $list, $extension)
+			{
+				$li = $list->appendChild($list->ownerDocument->createElement('li'));
+				$a = $li->appendChild($li->ownerDocument->createElement('a', $extension));
+				$a->setAttribute('href', getPHPLink($extension));
+				$a->setAttribute('target', '_blank');
+				return $list;
+			}, $parent->appendChild($parent->ownerDocument->createElement('ul')));
+		}
+	}
+
+	/**
+	 * Inverse of `extension_loaded`
+	 *
+	 * @param  string $name The extension name
+	 * @return boolean      If it is not loaded
+	 */
+	function extension_not_loaded($name)
+	{
+		return ! extension_loaded($name);
+	}
+
+	$main = \shgysk8zer0\DOM\HTML::getInstance()->createElement('main');
+	$extensions = array(
+		'PDO',
+		'dom',
+		'fileinfo',
+		'SPL',
+		'session',
+		'Reflection',
+		'SimpleXML',
+		'json',
+		'mcrypt',
+		'mysql',
+		'mysqli',
+		'pdo_mysql'
+	);
+
+	$extensions = array_filter($extensions, '\\' . __NAMESPACE__ . '\\extension_not_loaded');
+	listExtenions($extensions, $main);
+	unset($extensions);
+	return $main;
+}


### PR DESCRIPTION
## List required PHP extensions that have not been loaded. Fixes #94
### List of significant changes made
-  Create an array of PHP extensions that are required
-  Filter this array with `! extesion_loaded`
- Create a list of missing extensions with link to search on PHP.net

@KVSun/developers

See documentation of functions for details.
