### PR TITLE
Fix misc errors in Windows

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,10 +12,6 @@
             2,
             "tab"
         ],
-        "linebreak-style": [
-            2,
-            "unix"
-        ],
         "quotes": [
             2,
             "single"

--- a/.htaccess
+++ b/.htaccess
@@ -14,6 +14,7 @@ Options -Indexes +SymLinksIfOwnerMatch
 		SetEnv AUTOLOAD_DIR classes
 		SetEnv AUTOLOAD_EXTS .php
 		SetEnv AUTOLOAD_FUNC spl_autoload
+		SetEnv AUTOLOAD_SCRIPT ./autoloader.php
 	</IfModule>
 </IfModule>
 <IfModule !php5_module>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:js": "webpack",
     "build:icons": "php svgsprites.php",
     "build:all": "npm run build:css && npm run build:js && npm run build:icons",
-    "lint:js": "eslint  --ext .es6 --fix .",
+    "lint:js": "eslint  --ext .es6 .",
     "lint:php": "php unit.php",
     "update": "git submodule update --init --recursive",
     "test": "npm run lint:php && npm run lint:js",

--- a/test_funcs.php
+++ b/test_funcs.php
@@ -42,6 +42,10 @@ function get_scripts($dir = __DIR__)
  */
 function lint_scripts_recursive($dir = __DIR__)
 {
-	array_map(__NAMESPACE__ .  '\\lint_script', get_scripts($dir));
+	static $funcs;
+	if (is_null($funcs)) {
+		$funcs = \shgysk8zer0\Core\NamespacedFunction::load(__NAMESPACE__);
+	}
+	array_map($funcs->lint_script, get_scripts($dir));
 	array_map(__FUNCTION__, get_dirs($dir));
 }


### PR DESCRIPTION
- Do not require Unix style line endings
- Set AUTOLOAD_SCRIPT as an environment var
- Simplify linting of PHP scripts
- Remove `fix` flag for linting JS
