### PR TITLE
Bug 74

### DIFF
--- a/scripts/eventHandlers.es6
+++ b/scripts/eventHandlers.es6
@@ -87,6 +87,11 @@ function matchInput(input) {
 
 function getLink(click) {
 	click.preventDefault();
+	if (this.classList.contains('disabled')) {
+		return;
+	} else {
+		this.classList.add('disabled');
+	}
 	let url = new URL(this.href, location.origin);
 	let headers = new Headers();
 	headers.set('Accept', 'application/json');
@@ -96,7 +101,13 @@ function getLink(click) {
 	fetch(url, {
 		method: 'GET',
 		headers
-	}).then(updateFetchHistory).then(parseResponse).then(handleJSON).catch(reportError);
+	}).then(updateFetchHistory).then(parseResponse).then(json => {
+		handleJSON(json);
+		this.classList.remove('disabled');
+	}).catch(error => {
+		this.classList.remove('disabled');
+		reportError(error);
+	});
 }
 
 function toggleDetails() {

--- a/stylesheets/styles/btn.css
+++ b/stylesheets/styles/btn.css
@@ -1,0 +1,17 @@
+.disabled {
+	pointer-events: none;
+}
+button, [role="button"] {
+	transition: filter 300ms;
+}
+.disabled[role="button"], button:disabled {
+	cursor: progress;
+	background-image: linear-gradient(var(--highlight-color), var(--primary-color));
+	filter: blur(0.17em) grayscale(50%) opacity(80%);
+}
+a:not([role="button"]).disabled {
+	color: inherit;
+}
+:disabled svg, .disabled svg {
+	fill: #333;
+}

--- a/stylesheets/styles/import.css
+++ b/stylesheets/styles/import.css
@@ -15,3 +15,4 @@
 @import url("../core-css/data-filter.css");
 @import url("columns.css");
 @import url("icons.css");
+@import url("btn.css");


### PR DESCRIPTION
Disabled click events after click.Fixes #74 
- Uses CSS to set `pointer-events: none;`
- Adds disabled class to links
- Link click handlers do not execute if it has disabled class
- Add styles to disabled things.
