### PR TITLE
Animate Sun logo in header

### DIFF
--- a/components/header.php
+++ b/components/header.php
@@ -5,12 +5,7 @@ function loadHeader()
 	$header = \shgysk8zer0\DOM\HTML::getInstance()->createElement('header');
 	$header->append('h1', 'KV Sun Ad Insertion', [
 		'class' => 'center'
-	])->append('img', null, [
-		'alt' => 'KV Sun Logo',
-		'src' => 'sun.svg',
-		'width' => 266,
-		'height' => 90
-	]);
+	])->importHTML(file_get_contents('sun.svg'));
 	return $header;
 }
 return loadHeader();

--- a/stylesheets/styles/import.css
+++ b/stylesheets/styles/import.css
@@ -16,3 +16,4 @@
 @import url("columns.css");
 @import url("icons.css");
 @import url("btn.css");
+@import url("sunrise.css");

--- a/stylesheets/styles/sunrise.css
+++ b/stylesheets/styles/sunrise.css
@@ -1,0 +1,16 @@
+#sun {
+	animation-name: sunrise;
+	animation-duration: 10300ms;
+	/*animation-iteration-count: infinite;*/
+	animation-direction: alternate;
+	animation-fill-mode: forwards;
+	animation-play-state: running;
+	animation-timing-function: ease-in-out;
+}
+
+@keyframes sunrise {
+	from {
+		transform: translateY(80%);
+		filter: blur(1px) brightness(60%) opacity(0%);
+	}
+}

--- a/sun.svg
+++ b/sun.svg
@@ -55,6 +55,7 @@
 <stop stop-color="#f5cb00" offset="1"/>
 </linearGradient>
 </defs>
+<g id="sun">
 <rect height="5.9" width="230.63" y="0" x="-4.73" fill="url(#i)"/>
 <rect height="3.9794" width="230.68" y="8.3" x="-4.78" fill="url(#h)"/>
 <rect height="4.1" width="230.71" y="14.689" x="-4.81" fill="url(#g)"/>
@@ -65,5 +66,6 @@
 <rect height="1.7998" width="230.5" y="55.813" x="-4.6" fill="url(#b)"/>
 <rect opacity=".96" height="1.7" width="230" y="70" x="-4.1" fill="url(#a)"/>
 <circle cy="55" cx="160" r="52" fill="url(#j)"/>
+</g>
 <path d="m68.75 74.311 11 3.8 26-7.1 9.2-1.1 8-11 21 12 13-15 19-15 10 4.6 7.1-0.063 13 13 10 0.44 9.85-5.8v37.223h-156.95z" fill="url(#k)"/>
 </svg>


### PR DESCRIPTION
Add animation to header SVG. Fixes #123 
- Group and ID sun and rays in SVG
- Import `sun.svg` as HTML instead of as `<img>`
- Create and import CSS for animation
